### PR TITLE
Negative revpi readings and LAN sleep fixes

### DIFF
--- a/cryocon_26.py
+++ b/cryocon_26.py
@@ -6,7 +6,7 @@ class cryocon_26(LANDevice):
     """
     Cryogenic controller
     """
-    eol = b'\n';
+    eol = b'\n'
     _msg_end = ';\n'
     commands = {  # these are not case sensitive
         'identify': '*idn?',

--- a/cryocon_26.py
+++ b/cryocon_26.py
@@ -6,23 +6,23 @@ class cryocon_26(LANDevice):
     """
     Cryogenic controller
     """
-    def set_parameters(self):
-        self._msg_end = ';\n'
-        self.commands = {  # these are not case sensitive
-            'identify': '*idn?',
-            'getTempA': 'input? a:units k',
-            'getTempB': 'input? b:units k',
-            'getTempC': 'input? c:units k',
-            'getTempD': 'input? d:units k',
-            'getSP1': 'loop 1:setpt?',
-            'getSP2': 'loop 2:setpt?',
-            'getLp1Pwr': 'loop 1:htrread?',
-            'getLp2Pwr': 'loop 2:htrread?',
-            'setTempAUnits': 'input a:units k',
-            'setTempBUnits': 'input b:units k',
-            'setSP': 'loop {ch}:setpt {value}',
-        }
-        self.value_pattern = re.compile(f'(?P<value>{utils.number_regex})'.encode())
+    eol = b'\n';
+    _msg_end = ';\n'
+    commands = {  # these are not case sensitive
+        'identify': '*idn?',
+        'getTempA': 'input? a:units k',
+        'getTempB': 'input? b:units k',
+        'getTempC': 'input? c:units k',
+        'getTempD': 'input? d:units k',
+        'getSP1': 'loop 1:setpt?',
+        'getSP2': 'loop 2:setpt?',
+        'getLp1Pwr': 'loop 1:htrread?',
+        'getLp2Pwr': 'loop 2:htrread?',
+        'setTempAUnits': 'input a:units k',
+        'setTempBUnits': 'input b:units k',
+        'setSP': 'loop {ch}:setpt {value}',
+    }
+    value_pattern = re.compile(f'(?P<value>{utils.number_regex})'.encode())
 
     def execute_command(self, quantity, value):
         if quantity == 'setpoint':

--- a/mduino.py
+++ b/mduino.py
@@ -5,6 +5,7 @@ class mduino(Doberman.CheapSocketDevice):
     """
     IndustrialShield mduino. Use in conjunction with the .ino code
     """
+    eol = b'\n'
     def set_parameters(self):
         self._msg_start = '*'
         self._msg_end = '\r\n'

--- a/pfeiffer_tpg_dual.py
+++ b/pfeiffer_tpg_dual.py
@@ -3,12 +3,11 @@ import re  # EVERYBODY STAND BACK xkcd.com/208
 
 
 class pfeiffer_tpg_dual(LANDevice):
-    def set_parameters(self):
-        self._msg_begin = ''
-        self._msg_end = '\r\n\x05'
-        self.commands = {
-                'identify' : 'AYT',
-                }
-        self.value_pattern = re.compile(('(?P<status>[0-9]),(?P<value>%s)' %
-                                                    utils.number_regex).encode())
-
+    eol = b'\n'
+    _msg_begin = ''
+    _msg_end = '\r\n\x05'
+    commands = {
+        'identify' : 'AYT',
+        }
+    value_pattern = re.compile(('(?P<status>[0-9]),(?P<value>%s)' %
+                                              utils.number_regex).encode())

--- a/pfeiffer_tpg_dual.py
+++ b/pfeiffer_tpg_dual.py
@@ -4,7 +4,6 @@ import re  # EVERYBODY STAND BACK xkcd.com/208
 
 class pfeiffer_tpg_dual(LANDevice):
     eol = b'\n'
-    _msg_begin = ''
     _msg_end = '\r\n\x05'
     commands = {
         'identify' : 'AYT',

--- a/revpi.py
+++ b/revpi.py
@@ -78,7 +78,7 @@ class revpi(Device):
         else:  # two bytes
             with open('/dev/piControl0', 'rb+') as f:
                 f.seek(int(offset >> 8))
-                ret = int.from_bytes(f.read(2), 'little')
+                ret = int.from_bytes(f.read(2), 'little', signed=True)
         return ret
 
     def execute_command(self, target, value):
@@ -126,6 +126,7 @@ class revpi(Device):
         Drops faulty temperature measurements, otherwise leaves the conversion from DAC units to something sensible
         to a later function
         """
-        data = int(data)
+        return data # Not sure which faulty readings we are meant to drop, but certainly not all negative ones!
+        data = int(data) # Add a signed=True before wildly uncommenting!
         # skip faulty temperature measurements
         return None if name[0] == 'T' and data > 63000 else data

--- a/revpi.py
+++ b/revpi.py
@@ -123,10 +123,6 @@ class revpi(Device):
 
     def process_one_value(self, name, data):
         """
-        Drops faulty temperature measurements, otherwise leaves the conversion from DAC units to something sensible
-        to a later function
+        Do nothing. Leaves conversion to sensible units to later.
         """
-        return data # Not sure which faulty readings we are meant to drop, but certainly not all negative ones!
-        data = int(data) # Add a signed=True before wildly uncommenting!
-        # skip faulty temperature measurements
-        return None if name[0] == 'T' and data > 63000 else data
+        return data

--- a/revpi.py
+++ b/revpi.py
@@ -44,18 +44,18 @@ class revpi(Device):
         """
         if name not in self.positions:
             self.positions[name] = self.get_position(name)
-        offset = struct.unpack_from('>H', self.positions[name], 32)[0]
+        offset = struct.unpack_from('<H', self.positions[name], 32)[0]
         length = struct.unpack_from('B', self.positions[name], 36)[0]
         prm = (b'K'[0] << 8) + 16
         byte_array = bytearray([0, 0, 0, 0])
         if length == 1:  # single bit
             bit = struct.unpack_from('B', self.positions[name], 34)[0]
-            struct.pack_into('>H', byte_array, 0, offset)
+            struct.pack_into('<H', byte_array, 0, offset)
             struct.pack_into('B', byte_array, 2, bit)
             struct.pack_into('B', byte_array, 3, int(value))
             fcntl.ioctl(self.f, prm, byte_array)
         else:  # writing 2 bytes
-            self.f.seek(int(offset >> 8))
+            self.f.seek(offset)
             self.f.write(int(value).to_bytes(2, 'little'))
 
     def read(self, name):
@@ -65,20 +65,23 @@ class revpi(Device):
         """
         if name not in self.positions:
             self.positions[name] = self.get_position(name)
+      
+       
         value = bytearray([0, 0, 0, 0])
-        offset = struct.unpack_from('>H', self.positions[name], 32)[0]
+        offset = struct.unpack_from('<H', self.positions[name], 32)[0]
         length = struct.unpack_from('B', self.positions[name], 36)[0]
         prm = (b'K'[0] << 8) + 15
         if length == 1:  # single bit
             bit = struct.unpack_from('B', self.positions[name], 34)[0]
-            struct.pack_into('>H', value, 0, offset)
+            struct.pack_into('<H', value, 0, offset)
             struct.pack_into('B', value, 2, bit)
             fcntl.ioctl(self.f, prm, value)
             ret = value[3]
         else:  # two bytes
             with open('/dev/piControl0', 'rb+') as f:
-                f.seek(int(offset >> 8))
+                f.seek(offset)
                 ret = int.from_bytes(f.read(2), 'little', signed=True)
+        self.logger.debug(f'{name}: {ret}')
         return ret
 
     def execute_command(self, target, value):


### PR DESCRIPTION
Revpi values are signed integers - this is important for temperatures in degrees C, our "standard" temperature unit

Also fixes a few issues related to the LAN waiting PR on doberman